### PR TITLE
Exclude Plugin Host

### DIFF
--- a/check-url/plugin.php
+++ b/check-url/plugin.php
@@ -3,17 +3,20 @@
 Plugin Name: Check URL
 Plugin URI: http://code.google.com/p/yourls-check-url/
 Description: This plugin checks the reachability of an entered URL before creating the short link for it. An error is then returned if the entered URL is unreachable.
-Version: 1.1
+Version: 1.2
 Author: Aylwin
 Author URI: http://adigitalife.net/
 */
+
+Global $excludeLocal;
+$excludeLocal = true; // Whether to exclude checking links on the same host as the plugin resides
 
 // Hook our custom function into the 'shunt_add_new_link' filter
 yourls_add_filter( 'shunt_add_new_link', 'churl_reachability' );
 
 // Add a new link in the DB, either with custom keyword, or find one
 function churl_reachability( $churl_reachable, $url, $keyword = '' ) {
-	global $ydb;
+	global $ydb, $excludeLocal;
 
     // Check if the long URL is a different type of link
     $different_urls = array (
@@ -23,14 +26,19 @@ function churl_reachability( $churl_reachable, $url, $keyword = '' ) {
         array ( 'file://', 7 ),
         array ( 'telnet://', 9),
         array ( 'ssh://', 6),
-        array ( 'sip://', 6)
-        );
+        array ( 'sip://', 6),
+		);
 
     foreach ($different_urls as $url_type){
         if (substr( $url, 0, $url_type[1] ) == $url_type[0]){
             $churl_reachable = true; // No need to check reachability if URL type is different
             break;
-        }
+        } elseif ($excludeLocal) {
+			if (substr($url, 0, strlen('http://'.$_SERVER['SERVER_NAME'])) == 'http://'.$_SERVER['SERVER_NAME']) {
+				$churl_reachable = true;
+				break;
+			}
+		}
     }
 	
 	// Check if the long URL is a mailto


### PR DESCRIPTION
Implemented ability to ignore checking links on the domain that hosts
the plugin. This specifically fixes the compatibility with
YOURLS-Upload-and-Shorten
(https://github.com/fredl99/YOURLS-Upload-and-Shorten/issues/11)