### PR TITLE
Check for any 200 return code, to make sure we don't have a 301 at first

### DIFF
--- a/check-url/plugin.php
+++ b/check-url/plugin.php
@@ -59,11 +59,13 @@ function churl_reachability( $churl_reachable, $url, $keyword = '' ) {
 }
 
 function churl_url_exists( $churl ) {
-  $headers = get_headers($churl, 1);
+  $headers = get_headers($churl);
 
   // Declare the valid responses
-  if ( strpos($headers[0],"200 OK") != false) {
-    return true;
+  foreach($headers as $h){
+    if ( strpos($h,"200 OK") != false) {
+      return true;
+    }
   }
 
   return false;


### PR DESCRIPTION
Usually the first header is a 301 Moved Permanently. In order to get this module working, I'll just use any header to check for a 200 OK. It's still not the best solution, but it'll make it work.